### PR TITLE
Add validation support for arbitrary claims as arrays of strings

### DIFF
--- a/auth/jwt_test.go
+++ b/auth/jwt_test.go
@@ -1,7 +1,9 @@
 package auth
 
 import (
+	"regexp"
 	"testing"
+	"time"
 
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/stretchr/testify/assert"
@@ -37,9 +39,174 @@ func TestManualJWTManager(t *testing.T) {
 	assert.Nil(t, err)
 
 	claims := jwt.MapClaims{}
-	_, err = jwt.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (interface{}, error) {
-		return []byte("testing"), nil
-	})
+	_, err = jwt.ParseWithClaims(
+		tokenString, claims, func(token *jwt.Token) (interface{}, error) {
+			return []byte("testing"), nil
+		},
+	)
 	assert.Nil(t, err)
 	assert.Equal(t, claims["aud"], "foo")
+}
+
+func TestValidatableMapClaims_ValidateClaims(t *testing.T) {
+	tests := []struct {
+		name           string
+		expectedClaims ValidatableMapClaims
+		requestClaims  jwt.MapClaims
+		success        bool
+	}{
+		{
+			name: "valid claims",
+			expectedClaims: ValidatableMapClaims{
+				"aud": "test-aud",
+				"iss": "test-iss",
+				"sub": "test-sub",
+			},
+			requestClaims: jwt.MapClaims{
+				"aud": "test-aud",
+				"iss": "test-iss",
+				"sub": "test-sub",
+				"exp": time.Now().Add(time.Minute).Unix(),
+				"iat": time.Now().Unix(),
+			},
+			success: true,
+		},
+		{
+			name: "missing sub",
+			expectedClaims: ValidatableMapClaims{
+				"aud": "test-aud",
+				"iss": "test-iss",
+				"sub": "test-sub",
+			},
+			requestClaims: jwt.MapClaims{
+				"aud": "test-aud",
+				"iss": "test-iss",
+				"exp": time.Now().Add(time.Minute).Unix(),
+				"iat": time.Now().Unix(),
+			},
+			success: false,
+		},
+		{
+			name: "missing arbitrary claim",
+			expectedClaims: ValidatableMapClaims{
+				"aud":    "test-aud",
+				"iss":    "test-iss",
+				"sub":    "test-sub",
+				"target": "test-target",
+			},
+			requestClaims: jwt.MapClaims{
+				"aud": "test-aud",
+				"iss": "test-iss",
+				"sub": "test-sub",
+				"exp": time.Now().Add(time.Minute).Unix(),
+				"iat": time.Now().Unix(),
+			},
+			success: false,
+		},
+		{
+			name: "missing iat",
+			expectedClaims: ValidatableMapClaims{
+				"aud": "test-aud",
+				"iss": "test-iss",
+				"sub": "test-sub",
+			},
+			requestClaims: jwt.MapClaims{
+				"aud": "test-aud",
+				"iss": "test-iss",
+				"sub": "test-sub",
+				"exp": time.Now().Add(time.Minute).Unix(),
+			},
+			success: false,
+		},
+		{
+			name: "missing exp",
+			expectedClaims: ValidatableMapClaims{
+				"aud": "test-aud",
+				"iss": "test-iss",
+				"sub": "test-sub",
+			},
+			requestClaims: jwt.MapClaims{
+				"aud": "test-aud",
+				"iss": "test-iss",
+				"sub": "test-sub",
+				"iat": time.Now().Unix(),
+			},
+			success: false,
+		},
+		{
+			name: "regex claim match",
+			expectedClaims: ValidatableMapClaims{
+				"aud": regexp.MustCompile(`^test-aud$`),
+			},
+			requestClaims: jwt.MapClaims{
+				"aud": "test-aud",
+				"iss": "test-iss",
+				"sub": "test-sub",
+				"exp": time.Now().Add(time.Minute).Unix(),
+				"iat": time.Now().Unix(),
+			},
+			success: true,
+		},
+		{
+			name: "regex claim mismatch",
+			expectedClaims: ValidatableMapClaims{
+				"aud": regexp.MustCompile(`^test-aud$`),
+			},
+			requestClaims: jwt.MapClaims{
+				"aud": "invalid-aud",
+				"iss": "test-iss",
+				"sub": "test-sub",
+				"exp": time.Now().Add(time.Minute).Unix(),
+				"iat": time.Now().Unix(),
+			},
+			success: false,
+		},
+		{
+			name: "array mismatch",
+			expectedClaims: ValidatableMapClaims{
+				"aud":    "test-aud",
+				"groups": []string{"group1", "group2"},
+			},
+			requestClaims: jwt.MapClaims{
+				"aud":    "test-aud",
+				"iss":    "test-iss",
+				"sub":    "test-sub",
+				"groups": []string{"group1", "group2", "group3"},
+				"exp":    time.Now().Add(time.Minute).Unix(),
+				"iat":    time.Now().Unix(),
+			},
+			success: false,
+		},
+		{
+			name: "array match",
+			expectedClaims: ValidatableMapClaims{
+				"aud":    "test-aud",
+				"groups": []string{"group1", "group2"},
+			},
+			requestClaims: jwt.MapClaims{
+				"aud":    "test-aud",
+				"iss":    "test-iss",
+				"sub":    "test-sub",
+				"groups": []string{"group1", "group2"},
+				"exp":    time.Now().Add(time.Minute).Unix(),
+				"iat":    time.Now().Unix(),
+			},
+			success: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(
+			tt.name, func(t *testing.T) {
+				res, err := tt.expectedClaims.ValidateClaims(&tt.requestClaims)
+				if tt.success {
+					assert.NoError(t, err)
+					assert.True(t, res)
+				} else {
+					assert.Error(t, err)
+					assert.False(t, res)
+				}
+			},
+		)
+	}
 }


### PR DESCRIPTION
This adds to the `ValidatableMapClaims` to support validating an arbitrary (non-standard) claim which is an array of strings. Order is not enforced.

Fixes #5 